### PR TITLE
Move page titles to component

### DIFF
--- a/stubs/resources/js/Pages/Auth/ConfirmPassword.vue
+++ b/stubs/resources/js/Pages/Auth/ConfirmPassword.vue
@@ -17,7 +17,7 @@ const submit = () => {
 </script>
 
 <template>
-    <Head title="Confirm Password" />
+    <Head><title>Confirm Password</title></Head>
 
     <Layout>
         <div

--- a/stubs/resources/js/Pages/Auth/ForgotPassword.vue
+++ b/stubs/resources/js/Pages/Auth/ForgotPassword.vue
@@ -18,9 +18,8 @@ const submit = () => {
 }
 </script>
 
-
 <template>
-    <Head title="Forgot Password" />
+    <Head><title>Forgot Password</title></Head>
 
     <Layout>
         <div

--- a/stubs/resources/js/Pages/Auth/Login.vue
+++ b/stubs/resources/js/Pages/Auth/Login.vue
@@ -24,7 +24,7 @@ const submit = () => {
 </script>
 
 <template>
-    <Head title="Log in" />
+    <Head><title>Log in</title></Head>
 
     <Layout>
         <ValidationErrors class="mb-4" />

--- a/stubs/resources/js/Pages/Auth/Register.vue
+++ b/stubs/resources/js/Pages/Auth/Register.vue
@@ -21,9 +21,8 @@ const submit = () => {
 }
 </script>
 
-
 <template>
-    <Head title="Register" />
+    <Head><title>Register</title></Head>
 
     <Layout>
         <ValidationErrors class="mb-4" />

--- a/stubs/resources/js/Pages/Auth/ResetPassword.vue
+++ b/stubs/resources/js/Pages/Auth/ResetPassword.vue
@@ -26,7 +26,7 @@ const submit = () => {
 </script>
 
 <template>
-    <Head title="Reset Password" />
+    <Head><title>Reset Password</title></Head>
 
     <Layout>
         <ValidationErrors class="mb-4" />

--- a/stubs/resources/js/Pages/Auth/VerifyEmail.vue
+++ b/stubs/resources/js/Pages/Auth/VerifyEmail.vue
@@ -20,7 +20,7 @@ const verificationLinkSent = computed(() => props.status === 'verification-link-
 </script>
 
 <template>
-    <Head title="Email Verification" />
+    <Head><title>Email Verification</title></Head>
 
     <Layout>
         <div

--- a/stubs/resources/js/Pages/Dashboard.vue
+++ b/stubs/resources/js/Pages/Dashboard.vue
@@ -4,7 +4,7 @@ import { Head } from '@inertiajs/inertia-vue3'
 </script>
 
 <template>
-    <Head title="Dashboard" />
+    <Head><title>Dashboard</title></Head>
 
     <Layout>
         <template #header>

--- a/stubs/resources/js/Pages/Welcome.vue
+++ b/stubs/resources/js/Pages/Welcome.vue
@@ -14,7 +14,7 @@ const props = defineProps({
 </script>
 
 <template>
-    <Head title="Welcome" />
+    <Head><title>Welcome</title></Head>
 
     <div
         class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center sm:pt-0"


### PR DESCRIPTION
Simple change according the titles of the `Head` component in the pages, which should be a component instead of attribute.

https://github.com/inertiajs/inertia/blob/master/packages/inertia-vue3/index.d.ts#L96